### PR TITLE
docs: fix markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Use [Whimsy](https://whimsy.apache.org/roster/committee/cordova):
 3. Check the `72 hour board@ NOTICE period elapsed?` checkbox
 4. Select the `Add as committer` button
 
-or **[manually]**( https://www.apache.org/dev/pmc.html#SVNaccess).
+or **[manually](https://www.apache.org/dev/pmc.html#SVNaccess)**.
 
 ## 6. Once 72 hours has elapsed from the board@ notice, add the committer to the PMC committee-info.txt file and LDAP (PMC Chair only)
 


### PR DESCRIPTION
Currently the Markdown link/highlighting for manually doing step `5. When the new committer accepts the invite, create a new account for the user (PMC Chair only)` is broken
![image](https://user-images.githubusercontent.com/838003/56579027-5e863480-65cf-11e9-92cb-34d69da442d5.png)
