### PR TITLE
Make it optional to offer npm publish rights

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW_COMMITTER_AND_PMC.md
+++ b/.github/ISSUE_TEMPLATE/NEW_COMMITTER_AND_PMC.md
@@ -20,5 +20,5 @@ See the [README](../README.md) for details on each of the steps.
 - [ ] 8. Add the PMC member to the JIRA 'PMC' User Role [[details]](https://github.com/apache/cordova-new-committer-and-pmc#8-add-the-pmc-member-to-the-jira-pmc-user-role)
 - [ ] 9. Ask the PMC member to link their GitHub account [[details]](https://github.com/apache/cordova-new-committer-and-pmc#9-ask-the-pmc-member-to-link-their-github-account)
 - [ ] 10. Invite the PMC member to the `#pmc` Slack channel [[details]](https://github.com/apache/cordova-new-committer-and-pmc#10-invite-the-pmc-member-to-the-pmc-slack-channel)
-- [ ] 11. Optional: offer npm publish rights to the new PMC member
+- [ ] 11. Optional: offer npm publish rights to the new PMC member, if requested and required
 - [ ] Close this issue with a resolution note

--- a/.github/ISSUE_TEMPLATE/NEW_COMMITTER_AND_PMC.md
+++ b/.github/ISSUE_TEMPLATE/NEW_COMMITTER_AND_PMC.md
@@ -20,5 +20,5 @@ See the [README](../README.md) for details on each of the steps.
 - [ ] 8. Add the PMC member to the JIRA 'PMC' User Role [[details]](https://github.com/apache/cordova-new-committer-and-pmc#8-add-the-pmc-member-to-the-jira-pmc-user-role)
 - [ ] 9. Ask the PMC member to link their GitHub account [[details]](https://github.com/apache/cordova-new-committer-and-pmc#9-ask-the-pmc-member-to-link-their-github-account)
 - [ ] 10. Invite the PMC member to the `#pmc` Slack channel [[details]](https://github.com/apache/cordova-new-committer-and-pmc#10-invite-the-pmc-member-to-the-pmc-slack-channel)
-- [ ] 11. Offer npm publish rights to the new PMC member
+- [ ] 11. Optional: offer npm publish rights to the new PMC member
 - [ ] Close this issue with a resolution note


### PR DESCRIPTION
Followup to PR #20:

Unfortunately I did not see <https://github.com/apache/cordova-new-committer-and-pmc/pull/20#issuecomment-542362229> by @purplecabbage before merging #20.

While I would agree with <https://github.com/apache/cordova-new-committer-and-pmc/pull/20#issuecomment-542362229>, I do think this is a step that should not be forgotten when onboarding new committers.

I think it would be ideal to have a more gradual onboarding process for new members. This may involve a change in our process. Any ideas or suggestions?

/cc @purplecabbage @timbru31