### PR TITLE
[RFC] add pointers to gpg guides

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW_COMMITTER_AND_PMC.md
+++ b/.github/ISSUE_TEMPLATE/NEW_COMMITTER_AND_PMC.md
@@ -20,7 +20,8 @@ See the [README](../README.md) for details on each of the steps.
 - [ ] 8. Add the PMC member to the JIRA 'PMC' User Role [[details]](https://github.com/apache/cordova-new-committer-and-pmc#8-add-the-pmc-member-to-the-jira-pmc-user-role)
 - [ ] 9. Ask the PMC member to link their GitHub account [[details]](https://github.com/apache/cordova-new-committer-and-pmc#9-ask-the-pmc-member-to-link-their-github-account)
 - [ ] 10. Invite the PMC member to the `#pmc` Slack channel [[details]](https://github.com/apache/cordova-new-committer-and-pmc#10-invite-the-pmc-member-to-the-pmc-slack-channel)
-- [ ] 11. Optional: offer npm publish rights to the new PMC member, if requested and required; should send a pointer to the following guides to setting up gpg to sign releases:
+- [ ] 11. Optional: offer npm publish rights to the new PMC member, if requested and required; should send a pointer to the following guides to setting up gpg to sign and validate releases:
+
   - https://github.com/apache/cordova-coho/blob/master/docs/setting-up-gpg.md
   - https://www.apache.org/dev/new-committers-guide.html#set-up-security-and-pgp-keys
 - [ ] Close this issue with a resolution note

--- a/.github/ISSUE_TEMPLATE/NEW_COMMITTER_AND_PMC.md
+++ b/.github/ISSUE_TEMPLATE/NEW_COMMITTER_AND_PMC.md
@@ -20,5 +20,7 @@ See the [README](../README.md) for details on each of the steps.
 - [ ] 8. Add the PMC member to the JIRA 'PMC' User Role [[details]](https://github.com/apache/cordova-new-committer-and-pmc#8-add-the-pmc-member-to-the-jira-pmc-user-role)
 - [ ] 9. Ask the PMC member to link their GitHub account [[details]](https://github.com/apache/cordova-new-committer-and-pmc#9-ask-the-pmc-member-to-link-their-github-account)
 - [ ] 10. Invite the PMC member to the `#pmc` Slack channel [[details]](https://github.com/apache/cordova-new-committer-and-pmc#10-invite-the-pmc-member-to-the-pmc-slack-channel)
-- [ ] 11. Optional: offer npm publish rights to the new PMC member, if requested and required
+- [ ] 11. Optional: offer npm publish rights to the new PMC member, if requested and required; should send a pointer to the following guides to setting up gpg to sign releases:
+  - https://github.com/apache/cordova-coho/blob/master/docs/setting-up-gpg.md
+  - https://www.apache.org/dev/new-committers-guide.html#set-up-security-and-pgp-keys
 - [ ] Close this issue with a resolution note


### PR DESCRIPTION
triggered by [this discussion on the mailing list](https://lists.apache.org/thread.html/08dc538771e08fafe3b0a36170d687e11a856b7093d8ccbd51278a54%40%3Cdev.cordova.apache.org%3E)

I cannot say for sure yet whether the pointers belong here or maybe somewhere else.